### PR TITLE
Fix multidocs deploy branch checkout in CI

### DIFF
--- a/docs/multimake.jl
+++ b/docs/multimake.jl
@@ -57,7 +57,7 @@ function deploymultidocs(
     # the repository is often in a detached HEAD state, which causes `git pull` to fail.
     # We assume the environment is already set up with the correct commit to build.
 
-    has_branch = checkout_deploy_branch(branch)
+    checkout_deploy_branch(branch)
 
     for file in readdir(root_path; join = true)
         endswith(file, ".git") && continue
@@ -75,12 +75,7 @@ function deploymultidocs(
 
     if success(`git commit -m 'Aggregate documentation'`)
         @info "Pushing updated documentation"
-
-        if has_branch
-            run(`git push`)
-        else
-            run(`git push -u origin $branch`)
-        end
+        run(`git push origin HEAD:$branch`)
 
         run(`git checkout $main`)
     else

--- a/docs/multimake.jl
+++ b/docs/multimake.jl
@@ -50,6 +50,7 @@ function deploymultidocs(
     path::AbstractString;
     branch::String = "gh-multi-pages",
     main::String = "main",
+    remote::String = "origin",
 )
     root_path = normpath(joinpath(@__DIR__, ".."))
 
@@ -57,7 +58,7 @@ function deploymultidocs(
     # the repository is often in a detached HEAD state, which causes `git pull` to fail.
     # We assume the environment is already set up with the correct commit to build.
 
-    checkout_deploy_branch(branch)
+    checkout_deploy_branch(branch; remote)
 
     for file in readdir(root_path; join = true)
         endswith(file, ".git") && continue
@@ -75,7 +76,7 @@ function deploymultidocs(
 
     if success(`git commit -m 'Aggregate documentation'`)
         @info "Pushing updated documentation"
-        run(`git push origin HEAD:$branch`)
+        push_deploy_branch(branch; remote)
 
         run(`git checkout $main`)
     else

--- a/docs/multimake_utils.jl
+++ b/docs/multimake_utils.jl
@@ -1,5 +1,11 @@
-function checkout_deploy_branch(branch::AbstractString)
+function checkout_deploy_branch(branch::AbstractString; remote::AbstractString = "origin")
     if success(`git checkout $branch`)
+        return true
+    end
+
+    # GitHub Actions checks out only the triggering ref by default, so the
+    # deploy branch may exist on the remote but not in the local clone yet.
+    if success(`git fetch $remote $branch:$branch`) && success(`git checkout $branch`)
         return true
     end
 

--- a/docs/multimake_utils.jl
+++ b/docs/multimake_utils.jl
@@ -1,11 +1,18 @@
+branch_ref(branch::AbstractString) = "refs/heads/$branch"
+has_local_branch(branch::AbstractString) = success(`git show-ref --verify --quiet $(branch_ref(branch))`)
+
 function checkout_deploy_branch(branch::AbstractString; remote::AbstractString = "origin")
-    if success(`git checkout $branch`)
+    if has_local_branch(branch) && success(`git checkout $branch`)
         return true
     end
 
     # GitHub Actions checks out only the triggering ref by default, so the
     # deploy branch may exist on the remote but not in the local clone yet.
-    if success(`git fetch $remote $branch:$branch`) && success(`git checkout $branch`)
+    ref = branch_ref(branch)
+
+    if success(`git fetch $remote $ref:$ref`) &&
+       has_local_branch(branch) &&
+       success(`git checkout $branch`)
         return true
     end
 
@@ -14,4 +21,10 @@ function checkout_deploy_branch(branch::AbstractString; remote::AbstractString =
     end
 
     error("Cannot create new orphaned branch $branch.")
+end
+
+function push_deploy_branch(branch::AbstractString; remote::AbstractString = "origin")
+    run(`git push $remote HEAD:$(branch_ref(branch))`)
+
+    return nothing
 end

--- a/test/multimake_utils.jl
+++ b/test/multimake_utils.jl
@@ -1,5 +1,12 @@
 include(joinpath(@__DIR__, "..", "docs", "multimake_utils.jl"))
 
+function configure_git_user!()
+    run(`git config user.name QUBOTests`)
+    run(`git config user.email qubo-tests@example.com`)
+
+    return nothing
+end
+
 function commit_file!(name::AbstractString, contents::AbstractString, message::AbstractString)
     write(name, contents)
     run(`git add $name`)
@@ -10,8 +17,7 @@ end
 
 function initialize_git_repo!()
     run(`git init -b master`)
-    run(`git config user.name QUBOTests`)
-    run(`git config user.email qubo-tests@example.com`)
+    configure_git_user!()
     commit_file!("README.md", "# temp repo\n", "Initial commit")
 
     return nothing
@@ -72,6 +78,51 @@ function test_multimake_utils()
                         @test readchomp(`git branch --show-current`) == "gh-multi-pages"
                         @test chomp(read("branch.txt", String)) == "branch contents"
                         @test success(`git rev-parse --verify refs/heads/gh-multi-pages`)
+                    end
+                end
+            end
+        end
+
+        @testset "Uses explicit branch refs with matching tag names and custom remotes" begin
+            mktempdir() do remote_path
+                mktempdir() do source
+                    local tag_commit = ""
+
+                    cd(source) do
+                        initialize_git_repo!()
+                        run(`git init --bare $remote_path`)
+                        run(`git remote add upstream $remote_path`)
+                        run(`git push -u upstream master`)
+                        run(`git tag gh-multi-pages`)
+                        tag_commit = readchomp(`git rev-parse refs/tags/gh-multi-pages`)
+                        run(`git push upstream refs/tags/gh-multi-pages`)
+                        run(`git switch -c gh-multi-pages`)
+                        commit_file!("branch.txt", "branch contents\n", "Branch commit")
+                        push_deploy_branch("gh-multi-pages"; remote = "upstream")
+                    end
+
+                    mktempdir() do clone
+                        run(`git clone --origin upstream --branch master --single-branch $remote_path $clone`)
+
+                        cd(clone) do
+                            configure_git_user!()
+
+                            has_branch = checkout_deploy_branch("gh-multi-pages"; remote = "upstream")
+
+                            @test has_branch
+                            @test readchomp(`git branch --show-current`) == "gh-multi-pages"
+                            @test chomp(read("branch.txt", String)) == "branch contents"
+
+                            commit_file!("branch.txt", "updated branch contents\n", "Update branch contents")
+                            push_deploy_branch("gh-multi-pages"; remote = "upstream")
+                        end
+                    end
+
+                    mktempdir() do verify
+                        run(`git clone --origin upstream --branch gh-multi-pages $remote_path $verify`)
+
+                        @test chomp(read(joinpath(verify, "branch.txt"), String)) == "updated branch contents"
+                        @test readchomp(`git --git-dir=$remote_path rev-parse refs/tags/gh-multi-pages`) == tag_commit
                     end
                 end
             end

--- a/test/multimake_utils.jl
+++ b/test/multimake_utils.jl
@@ -47,6 +47,35 @@ function test_multimake_utils()
                 end
             end
         end
+
+        @testset "Fetches existing remote branch when clone is single-branch" begin
+            mktempdir() do origin
+                mktempdir() do source
+                    cd(source) do
+                        initialize_git_repo!()
+                        run(`git init --bare $origin`)
+                        run(`git remote add origin $origin`)
+                        run(`git push -u origin master`)
+                        run(`git switch -c gh-multi-pages`)
+                        commit_file!("branch.txt", "branch contents\n", "Branch commit")
+                        run(`git push -u origin gh-multi-pages`)
+                    end
+                end
+
+                mktempdir() do clone
+                    run(`git clone --branch master --single-branch $origin $clone`)
+
+                    cd(clone) do
+                        has_branch = checkout_deploy_branch("gh-multi-pages")
+
+                        @test has_branch
+                        @test readchomp(`git branch --show-current`) == "gh-multi-pages"
+                        @test read("branch.txt", String) == "branch contents\n"
+                        @test success(`git rev-parse --verify refs/heads/gh-multi-pages`)
+                    end
+                end
+            end
+        end
     end
 
     return nothing

--- a/test/multimake_utils.jl
+++ b/test/multimake_utils.jl
@@ -70,7 +70,7 @@ function test_multimake_utils()
 
                         @test has_branch
                         @test readchomp(`git branch --show-current`) == "gh-multi-pages"
-                        @test read("branch.txt", String) == "branch contents\n"
+                        @test chomp(read("branch.txt", String)) == "branch contents"
                         @test success(`git rev-parse --verify refs/heads/gh-multi-pages`)
                     end
                 end


### PR DESCRIPTION
## Summary
- fetch `gh-multi-pages` into a local branch when Actions only checked out `master`
- push aggregated documentation with an explicit refspec instead of relying on upstream tracking metadata
- add a regression test for the single-branch clone case that caused the deploy failure

## Root cause
The `build-multidocs` job on March 18, 2026 failed because the workflow clone only had `master` locally, so `docs/multimake.jl` created an orphan `gh-multi-pages` branch and the push was rejected as non-fast-forward:
https://github.com/JuliaQUBO/QUBO.jl/actions/runs/23271654546/job/67665783548

## Testing
- `JULIA_DEPOT_PATH=$PWD/.julia-depot:$HOME/.julia julia --project=. -e 'using Pkg; Pkg.test()'`
