### PR TITLE
Document constraint penalty hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,45 @@ end
 
 </details>
 
+### Constraint Penalty Hints
+
+To set a custom penalty for a constraint, create the constraint first and then
+attach `ToQUBO.Attributes.ConstraintEncodingPenaltyHint()` to the returned
+constraint reference before calling `optimize!`.
+There is no special combined macro for this in JuMP; the intended workflow is
+to define the constraint and immediately set the penalty hint on it.
+
+```julia
+using JuMP
+using QUBO
+
+model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+@variable(model, x[1:3], Bin)
+
+c = @constraint(model, x[1] + x[2] + x[3] <= 2)
+set_attribute(c, ToQUBO.Attributes.ConstraintEncodingPenaltyHint(), 20.0)
+
+@objective(model, Max, x[1] + 2 * x[2] + 3 * x[3])
+
+optimize!(model)
+
+rho = get_attribute(c, ToQUBO.Attributes.ConstraintEncodingPenalty())
+```
+
+For a container of constraints, broadcast `set_attribute` across the container.
+This works both for a common penalty and for per-constraint penalties with the
+same shape as the constraint container.
+
+```julia
+c = @constraint(model, [i in 1:3], x[i] <= 1)
+
+set_attribute.(c, Ref(ToQUBO.Attributes.ConstraintEncodingPenaltyHint()), 5.0)
+
+rho = [5.0, 10.0, 20.0]
+set_attribute.(c, Ref(ToQUBO.Attributes.ConstraintEncodingPenaltyHint()), rho)
+```
+
 ## Overview 🗺️
 
 <div align="left">

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -67,6 +67,45 @@ end
 
 ```
 
+## Constraint Penalties
+
+To set a custom penalty for a constraint, create the constraint first and then
+set `ToQUBO.Attributes.ConstraintEncodingPenaltyHint()` on the returned
+constraint reference before `optimize!`.
+There is no combined `@constraint` syntax for this in JuMP, so the usual
+pattern is to define the constraint and immediately attach the hint.
+
+```julia
+using JuMP
+using QUBO
+
+model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+@variable(model, x[1:3], Bin)
+
+c = @constraint(model, x[1] + x[2] + x[3] <= 2)
+set_attribute(c, ToQUBO.Attributes.ConstraintEncodingPenaltyHint(), 20.0)
+
+@objective(model, Max, x[1] + 2 * x[2] + 3 * x[3])
+
+optimize!(model)
+
+rho = get_attribute(c, ToQUBO.Attributes.ConstraintEncodingPenalty())
+```
+
+For many constraints, broadcast `set_attribute` across the constraint
+container. This lets you assign either the same penalty to all constraints or a
+different penalty to each one.
+
+```julia
+c = @constraint(model, [i in 1:3], x[i] <= 1)
+
+set_attribute.(c, Ref(ToQUBO.Attributes.ConstraintEncodingPenaltyHint()), 5.0)
+
+rho = [5.0, 10.0, 20.0]
+set_attribute.(c, Ref(ToQUBO.Attributes.ConstraintEncodingPenaltyHint()), rho)
+```
+
 ```@raw html
 <div align="center">
     <h2>QUBO.jl Packages</h2>


### PR DESCRIPTION
## Summary
- document how to set ToQUBO.Attributes.ConstraintEncodingPenaltyHint() on a single constraint
- document how to apply the same or different penalty hints to a container of constraints with broadcasting
- show how to retrieve the effective constraint penalty after optimize!

Closes #7.

## Verification
- built the docs locally with docs/make.jl using --skip-deploy
