### PR TITLE
Fix duplicated path segment in docs badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Code Coverage](https://codecov.io/gh/JuliaQUBO/QUBO.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/JuliaQUBO/QUBO.jl)
 [![CI](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/QUBO.jl/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaqubo.github.io/QUBO.jl/QUBO.jl/dev/)
+[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaqubo.github.io/QUBO.jl/dev/)
 [![Zenodo/DOI](https://zenodo.org/badge/614041491.svg)](https://zenodo.org/badge/latestdoi/614041491)
 [![JuliaCon 2022](https://img.shields.io/badge/JuliaCon-2022-9558b2)](https://www.youtube.com/watch?v=OTmzlTbqdNo)
 [![arXiv](https://img.shields.io/badge/arXiv-2307.02577-b31b1b.svg)](https://arxiv.org/abs/2307.02577)


### PR DESCRIPTION
## Summary

- Fixes the docs badge link in `README.md` (line 11), which contained a duplicated `QUBO.jl` path segment causing the badge to link to a non-existent page
- `https://juliaqubo.github.io/QUBO.jl/QUBO.jl/dev/` → `https://juliaqubo.github.io/QUBO.jl/dev/`

Closes #18

## Test plan

- [ ] Verify the docs badge in the rendered README links to the correct documentation page