### PR TITLE
Add QUBOTools plotting regression coverage

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/qubotools_plots.jl
+++ b/test/qubotools_plots.jl
@@ -1,0 +1,37 @@
+using RecipesBase
+
+function solved_qubo_model()
+    model = Model(() -> ToQUBO.Optimizer(ExactSampler.Optimizer))
+
+    @variable(model, x[1:3], Bin)
+    @objective(model, Min, x[1] * x[2] + x[2] * x[3] - x[1] - x[3])
+
+    optimize!(model)
+
+    return model
+end
+
+function test_qubotools_plots()
+    @testset "QUBOTools Plots" begin
+        model = solved_qubo_model()
+
+        backend = QUBOTools.backend(model)
+
+        @test backend isa QUBOTools.Model
+        @test QUBOTools.dimension(backend) == 3
+
+        for plot_type in (
+            QUBOTools.ModelDensityPlot,
+            QUBOTools.SystemLayoutPlot,
+            QUBOTools.EnergyFrequencyPlot,
+            QUBOTools.EnergyDistributionPlot,
+        )
+            plot = plot_type(model)
+            recipe_output = RecipesBase.apply_recipe(Dict{Symbol,Any}(), plot)
+
+            @test !isempty(recipe_output)
+        end
+    end
+
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,10 +6,12 @@ include("spin_model.jl")
 include("multimake_utils.jl")
 include("docs_assets.jl")
 include("package_metadata.jl")
+include("qubotools_plots.jl")
 
 function main()
     test_docs_assets()
     test_package_metadata()
+    test_qubotools_plots()
     test_spin_model()
     test_multimake_utils()
 


### PR DESCRIPTION
## Summary

- Add regression coverage for the QUBOTools plotting path documented in issue #8.
- Verify `QUBOTools.backend(::JuMP.Model)` returns the compiled QUBOTools model for a solved QUBO.jl/JuMP model.
- Exercise the four documented QUBOTools plot recipe wrappers with a `JuMP.Model`: `ModelDensityPlot`, `SystemLayoutPlot`, `EnergyFrequencyPlot`, and `EnergyDistributionPlot`.
- Add `RecipesBase` as a test-only dependency so the recipes can be checked without pulling in Plots.jl.

## Tests run

- `JULIA_DEPOT_PATH=/home/bernalde/repos/QUBO.jl/.julia-depot julia --project=/tmp/qubo-issue8-devtest2-env.n2QYlW -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.test("QUBO")'`
  - Result: passed, including `QUBOTools Plots | 6/6`.
- `JULIA_DEPOT_PATH=/home/bernalde/repos/QUBO.jl/.julia-depot julia --project=/tmp/qubo-issue8-docs-env.3NetJj docs/make.jl --skip-deploy`
  - Result: passed.
- `JULIA_DEPOT_PATH=/home/bernalde/repos/QUBO.jl/.julia-depot julia --project=/tmp/qubo-issue8-docs-env.3NetJj docs/multimake.jl --skip-deploy`
  - Result: passed.

## Notes

- No runtime dependencies were added. `RecipesBase` is only added to `test/Project.toml`.
- The code and documentation portions referenced in the issue comments were already present on `main`; this PR adds direct regression coverage for that behavior on the current dependency stack.

Closes #8
