### PR TITLE
Skip docs deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,11 @@ jobs:
           version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(path=@__DIR__); Pkg.instantiate()'
+      - name: Build docs
+        if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+        run: julia --project=docs/ docs/make.jl --skip-deploy
       - name: Build and deploy
+        if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs/ docs/make.jl


### PR DESCRIPTION
QUBO.jl currently has the same main docs deploy shape as the repos where Dependabot PRs failed: `docs/make.jl` supports `--skip-deploy`, but the documentation workflow always runs the deploy path in the primary docs job.

This keeps docs builds running for Dependabot PRs but passes `--skip-deploy` so the preview push is skipped. Normal pushes and non-Dependabot PRs still use the existing deploy path. The multidocs job already skips deploy for pull requests and is unchanged.

Verification:
- `git diff --check`
- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=@__DIR__); Pkg.instantiate()'`
- `julia --project=docs/ docs/make.jl --skip-deploy`