### PR TITLE
Benchmark julia-actions/cache for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
## Summary

- Add `julia-actions/cache@v3` to the CI matrix after `julia-actions/setup-julia@v3`.
- Leave package code and dependency metadata unchanged.
- Benchmark one cold-cache run and one warm-cache rerun on the same branch.

## Benchmark Results

Baseline from issue 36:

| Job | Baseline | Cold cache | Warm cache | Warm vs baseline |
| --- | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m43s | 2m33s | 1m30s | -73s (-45%) |
| Julia 1 Ubuntu | 4m17s | 4m07s | 1m40s | -157s (-61%) |
| Julia 1 Windows | 5m45s | 5m54s | 2m43s | -182s (-53%) |

Critical path improves from 5m45s baseline to 2m43s warm-cache, a 3m02s / 53% reduction. This meets both acceptance thresholds from issue 36: the slowest job improves by more than 60 seconds and the overall critical path improves by more than 20%.

## Cold Cache Step Timings

Run: https://github.com/JuliaQUBO/QUBO.jl/actions/runs/27123051668/attempts/1

| Job | Total | setup-julia | cache | buildpkg | runtest | coverage | codecov | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m33s | 5s | 1s | 15s | 1m45s | 17s | 2s | 3s |
| Julia 1 Ubuntu | 4m07s | 8s | <1s | 11s | 3m13s | 22s | 2s | 4s |
| Julia 1 Windows | 5m54s | 24s | 1s | 31s | 3m52s | 28s | 16s | 10s |

Cold-cache logs showed `No cache found` followed by `Cache saved successfully` for all three matrix jobs.

## Warm Cache Step Timings

Run: https://github.com/JuliaQUBO/QUBO.jl/actions/runs/27123051668/attempts/2

| Job | Total | setup-julia | cache restore | buildpkg | runtest | coverage | codecov | cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 1m30s | 5s | 5s | 10s | 54s | 5s | 2s | 4s |
| Julia 1 Ubuntu | 1m40s | 8s | 6s | 9s | 53s | 3s | 2s | 9s |
| Julia 1 Windows | 2m43s | 17s | 15s | 11s | 1m15s | 4s | 9s | 19s |

Warm-cache logs showed `Cache hit for restore-key`, `Cache restored successfully`, and `Cache saved successfully` for all three matrix jobs.

## Tests

- `git diff --check` passed.
- PR CI passed on the cold-cache run.
- PR CI passed on the warm-cache rerun.
- `julia --project=. -e 'using Pkg; Pkg.test()'` did not run tests locally: Julia 1.10.11 failed during package instantiation because `OpenSSL_jll` source was unavailable in the local depot and the manifest was resolved with Julia 1.12.0.
- `julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` did not run tests locally: dependency resolution failed before tests because the manifest fixes `QUBOTools` at `0.13.0` while `Project.toml` restricts `QUBOTools` to `0.12`.

Closes #36
