### PR TITLE
Avoid formatter parse issue in docs build script

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(;
     doctest  = true,
     clean    = true,
     warnonly = [:missing_docs],
-    format   = Documenter.HTML( #
+    format   = Documenter.HTML(
         assets     = ["assets/extra_styles.css", "assets/mermaid-init.js", "assets/favicon.ico"],
         edit_link  = "main",
         mathengine = Documenter.KaTeX(),


### PR DESCRIPTION
## Summary

- Remove the trailing no-op comment after `Documenter.HTML(` in `docs/make.jl`.
- Keep the existing Documenter configuration and readable layout unchanged.

## Why

Julia accepts the previous syntax, but JuliaFormatter reports a parse warning around this call site. Removing the trailing comment lets the formatter parse the file cleanly without changing docs behavior.

## Verification

- `julia --project=. -e 'using Pkg; Pkg.test()'` in a clean temp copy without local ignored manifests.
- `julia --project=docs/ -e 'using Pkg; Pkg.develop(path=@__DIR__); Pkg.instantiate()'` in the temp copy.
- `julia --project=docs/ docs/make.jl --skip-deploy` in the temp copy.
- JuliaFormatter no longer emits the previous parse warning for `docs/make.jl`; it still reports `ok = false` if run in check mode because the current formatter config would reflow existing layout.
