### PR TITLE
Document release guardrail roles

### DIFF
--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -87,7 +87,8 @@ that normal unit tests can miss:
 Use the QUBO.jl ecosystem canary after release work reaches the registry, or
 whenever a coordinated release wave changes cross-package compatibility. The
 canary composes the latest registered package versions in fresh environments
-and prints the registered compatibility matrix on failure. It is the
+and prints the registered compatibility matrix on every run, then again on
+resolution failure. It is the
 post-release coordination check: it verifies that the ecosystem still installs
 and imports together, but it is not a substitute for package-local preflight
 before Registrator is triggered.

--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -71,6 +71,32 @@ with explicit `contents: write` and `pull-requests: write` permissions and a
 dedicated secret such as `COMPATHELPER_PRIV` when the workflow must push
 branches that trigger CI.
 
+## Release Guardrails
+
+Use package-local release checks before tagging or registering an individual
+package release. The release preflight belongs in the package repository, for
+example `scripts/release_check.jl`, and should catch release-sensitive metadata
+that normal unit tests can miss:
+
+- root, docs, and test `Project.toml` version and compatibility drift;
+- release-note sections needed by General registry AutoMerge, especially
+  `Breaking changes` and `Changelog` wording for pre-1.0 minor releases;
+- TagBot, Registrator, General pull request, and fresh `Pkg.add` verification
+  checklist items.
+
+Use the QUBO.jl ecosystem canary after release work reaches the registry, or
+whenever a coordinated release wave changes cross-package compatibility. The
+canary composes the latest registered package versions in fresh environments
+and prints the registered compatibility matrix on failure. It is the
+post-release coordination check: it verifies that the ecosystem still installs
+and imports together, but it is not a substitute for package-local preflight
+before Registrator is triggered.
+
+When a release wave changes shared bounds such as `QUBODrivers` or
+`QUBOTools`, check the canary or run `scripts/compat_matrix.jl` from this
+repository after the package registrations land. Track any stale downstream
+bounds in the downstream package repository rather than weakening the canary.
+
 ## Rollout Order
 
 Apply the policy to package repositories before solver or adapter repositories

--- a/test/docs_assets.jl
+++ b/test/docs_assets.jl
@@ -39,6 +39,10 @@ function test_docs_assets()
         @test occursin("package-ecosystem: \"julia\"", maintenance)
         @test occursin("omits `test/` because `test/Project.toml` has no `[compat]`", maintenance)
         @test occursin("COMPATHELPER_PRIV", maintenance)
+        @test occursin("scripts/release_check.jl", maintenance)
+        @test occursin("Breaking changes", maintenance)
+        @test occursin("post-release coordination check", maintenance)
+        @test occursin("scripts/compat_matrix.jl", maintenance)
     end
 
     return nothing

--- a/test/docs_assets.jl
+++ b/test/docs_assets.jl
@@ -42,6 +42,7 @@ function test_docs_assets()
         @test occursin("scripts/release_check.jl", maintenance)
         @test occursin("Breaking changes", maintenance)
         @test occursin("post-release coordination check", maintenance)
+        @test occursin("compatibility matrix on every run", maintenance)
         @test occursin("scripts/compat_matrix.jl", maintenance)
     end
 


### PR DESCRIPTION
Summary
- Add a Release Guardrails section to `docs/src/maintenance.md`.
- Explain when package-local `scripts/release_check.jl` preflight should run versus when the QUBO.jl ecosystem canary/compat matrix should be used.
- Add docs-asset assertions so the maintenance guidance remains covered by tests.

Tests
- `julia --project=. -e 'using Test; include("test/docs_assets.jl"); test_docs_assets()'` passed.
- `julia --project=. -e 'using Pkg; Pkg.test()'` passed from a clean detached worktree at `/tmp/QUBO-issue44-test-750cffa3`.
- In the main checkout, `Pkg.test()` was not used for the final result because ignored local manifests (`Manifest.toml`, `docs/Manifest.toml`, `test/Manifest.toml`) are present and produced resolver/test-environment failures unrelated to this change.

Branch Hygiene
- Base branch: `main`.
- Source branch: `fix/issue-44-release-guardrails-docs`.
- Source branch point: current `origin/main` at `d136499`.
- Stacked status: not stacked.
- Prerequisite PRs: none.

Refs #44.
