### PR TITLE
[codex] Enforce latest core packages in ecosystem canary

### DIFF
--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -28,10 +28,12 @@ jobs:
       - name: Print compat matrix
         run: >
           julia scripts/compat_matrix.jl
+          QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
       - name: Resolve and import pure-Julia tier
         run: >
           julia scripts/ecosystem_canary.jl --tier tier-1
+          QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
 
   tier-2:
@@ -46,6 +48,7 @@ jobs:
       - name: Print compat matrix
         run: >
           julia scripts/compat_matrix.jl
+          QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
           DWave PySA CIMOptimizer QiskitOpt
       - name: Resolve and import Python-backed tier
@@ -55,5 +58,6 @@ jobs:
           --allow-import-failure PySA
           --allow-import-failure CIMOptimizer
           --allow-import-failure QiskitOpt
+          QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
           DWave PySA CIMOptimizer QiskitOpt

--- a/.github/workflows/ecosystem-canary.yml
+++ b/.github/workflows/ecosystem-canary.yml
@@ -28,11 +28,13 @@ jobs:
       - name: Print compat matrix
         run: >
           julia scripts/compat_matrix.jl
+          PseudoBooleanOptimization
           QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
       - name: Resolve and import pure-Julia tier
         run: >
           julia scripts/ecosystem_canary.jl --tier tier-1
+          PseudoBooleanOptimization
           QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
 
@@ -48,6 +50,7 @@ jobs:
       - name: Print compat matrix
         run: >
           julia scripts/compat_matrix.jl
+          PseudoBooleanOptimization
           QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
           DWave PySA CIMOptimizer QiskitOpt
@@ -58,6 +61,7 @@ jobs:
           --allow-import-failure PySA
           --allow-import-failure CIMOptimizer
           --allow-import-failure QiskitOpt
+          PseudoBooleanOptimization
           QUBOTools ToQUBO QUBODrivers
           QUBO QUBOLib MQLib TenSolver QuantumAnnealingInterface
           DWave PySA CIMOptimizer QiskitOpt

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ The ecosystem canary composes the latest registered versions of maintained QUBO
 packages in fresh Julia environments to catch compatibility drift across
 package boundaries. It also fails when `PseudoBooleanOptimization`,
 `QUBOTools`, `ToQUBO`, or `QUBODrivers` resolve below their latest registered
-versions. A red canary means at least one tier no longer resolves, imports, or
-reaches the latest core stack; inspect the workflow log's compatibility matrix
-first, then update the offending package bounds or release the missing
-compatibility work.
+versions that are stable, unyanked, and compatible with the Julia version
+running the canary. A red canary means at least one tier no longer resolves,
+imports, or reaches the latest core stack; inspect the workflow log's
+compatibility matrix first, then update the offending package bounds or release
+the missing compatibility work.
 
 ## QUBO? 🟦
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ This project aggregates and extends functionality from its complementary package
 
 The ecosystem canary composes the latest registered versions of maintained QUBO
 packages in fresh Julia environments to catch compatibility drift across
-package boundaries. A red canary means at least one tier no longer resolves or
-imports together; inspect the workflow log's compatibility matrix first, then
-update the offending package bounds or release the missing compatibility work.
+package boundaries. It also fails when `QUBOTools`, `ToQUBO`, or
+`QUBODrivers` resolve below their latest registered versions. A red canary
+means at least one tier no longer resolves, imports, or reaches the latest core
+stack; inspect the workflow log's compatibility matrix first, then update the
+offending package bounds or release the missing compatibility work.
 
 ## QUBO? 🟦
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ This project aggregates and extends functionality from its complementary package
 
 The ecosystem canary composes the latest registered versions of maintained QUBO
 packages in fresh Julia environments to catch compatibility drift across
-package boundaries. It also fails when `QUBOTools`, `ToQUBO`, or
-`QUBODrivers` resolve below their latest registered versions. A red canary
-means at least one tier no longer resolves, imports, or reaches the latest core
-stack; inspect the workflow log's compatibility matrix first, then update the
-offending package bounds or release the missing compatibility work.
+package boundaries. It also fails when `PseudoBooleanOptimization`,
+`QUBOTools`, `ToQUBO`, or `QUBODrivers` resolve below their latest registered
+versions. A red canary means at least one tier no longer resolves, imports, or
+reaches the latest core stack; inspect the workflow log's compatibility matrix
+first, then update the offending package bounds or release the missing
+compatibility work.
 
 ## QUBO? 🟦
 

--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -90,8 +90,11 @@ canary composes the latest registered package versions in fresh environments
 and prints the registered compatibility matrix on every run, then again on
 resolution failure. It also verifies that the resolved
 `PseudoBooleanOptimization`, `QUBOTools`, `ToQUBO`, and `QUBODrivers` versions
-are the latest registered releases, so stale downstream bounds are caught even
-when the resolver can still find an older compatible solution. It is the
+are the latest stable, unyanked registered releases compatible with the Julia
+version running the canary, so stale downstream bounds are caught even when the
+resolver can still find an older compatible solution. The core freshness gate
+is intentionally global: custom runs should include the core packages in the
+package list, because a missing core package is treated as stale. It is the
 post-release coordination check: it verifies that the ecosystem still installs
 and imports together, but it is not a substitute for package-local preflight
 before Registrator is triggered.

--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -88,12 +88,13 @@ Use the QUBO.jl ecosystem canary after release work reaches the registry, or
 whenever a coordinated release wave changes cross-package compatibility. The
 canary composes the latest registered package versions in fresh environments
 and prints the registered compatibility matrix on every run, then again on
-resolution failure. It also verifies that the resolved `QUBOTools`, `ToQUBO`,
-and `QUBODrivers` versions are the latest registered releases, so stale
-downstream bounds are caught even when the resolver can still find an older
-compatible solution. It is the post-release coordination check: it verifies
-that the ecosystem still installs and imports together, but it is not a
-substitute for package-local preflight before Registrator is triggered.
+resolution failure. It also verifies that the resolved
+`PseudoBooleanOptimization`, `QUBOTools`, `ToQUBO`, and `QUBODrivers` versions
+are the latest registered releases, so stale downstream bounds are caught even
+when the resolver can still find an older compatible solution. It is the
+post-release coordination check: it verifies that the ecosystem still installs
+and imports together, but it is not a substitute for package-local preflight
+before Registrator is triggered.
 
 When a release wave changes shared bounds such as `QUBODrivers` or
 `QUBOTools`, check the canary or run `scripts/compat_matrix.jl` from this

--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -88,10 +88,12 @@ Use the QUBO.jl ecosystem canary after release work reaches the registry, or
 whenever a coordinated release wave changes cross-package compatibility. The
 canary composes the latest registered package versions in fresh environments
 and prints the registered compatibility matrix on every run, then again on
-resolution failure. It is the
-post-release coordination check: it verifies that the ecosystem still installs
-and imports together, but it is not a substitute for package-local preflight
-before Registrator is triggered.
+resolution failure. It also verifies that the resolved `QUBOTools`, `ToQUBO`,
+and `QUBODrivers` versions are the latest registered releases, so stale
+downstream bounds are caught even when the resolver can still find an older
+compatible solution. It is the post-release coordination check: it verifies
+that the ecosystem still installs and imports together, but it is not a
+substitute for package-local preflight before Registrator is triggered.
 
 When a release wave changes shared bounds such as `QUBODrivers` or
 `QUBOTools`, check the canary or run `scripts/compat_matrix.jl` from this

--- a/scripts/ecosystem_canary.jl
+++ b/scripts/ecosystem_canary.jl
@@ -2,6 +2,8 @@
 
 using Pkg
 
+const CORE_PACKAGE_NAMES = ["QUBOTools", "ToQUBO", "QUBODrivers"]
+
 function parse_args(args)
     tier = "custom"
     allow_import_failure = Set{String}()
@@ -35,6 +37,10 @@ function ensure_general_registry()
     else
         Pkg.Registry.update()
     end
+    registries = Pkg.Registry.reachable_registries()
+    matches = filter(registry -> registry.name == "General", registries)
+    isempty(matches) && error("General registry is not available")
+    return only(matches)
 end
 
 function print_compat_matrix(packages)
@@ -47,11 +53,71 @@ function print_compat_matrix(packages)
     end
 end
 
+function latest_registered_versions(registry, package_names)
+    uuid_by_name = Dict(entry.name => uuid for (uuid, entry) in registry.pkgs)
+    versions = Dict{String,VersionNumber}()
+    for package in package_names
+        uuid = get(uuid_by_name, package, nothing)
+        uuid === nothing && error("$package is not available in the General registry")
+        info = Pkg.Registry.registry_info(registry.pkgs[uuid])
+        versions[package] = maximum(keys(info.version_info))
+    end
+    return versions
+end
+
+function resolved_versions(package_names)
+    names = Set(package_names)
+    versions = Dict{String,VersionNumber}()
+    for package in values(Pkg.dependencies())
+        package.name in names || continue
+        if package.version === nothing
+            error("resolved package $(package.name) does not have a registry version")
+        end
+        versions[package.name] = package.version
+    end
+    return versions
+end
+
+function core_version_results(package_names, latest_versions, manifest_versions)
+    return map(package_names) do package
+        latest = get(latest_versions, package, nothing)
+        resolved = get(manifest_versions, package, nothing)
+        (; package, resolved, latest, ok = resolved !== nothing && resolved == latest)
+    end
+end
+
+version_label(version) = version === nothing ? "missing" : string(version)
+
+function check_latest_core_packages(registry, tier, packages)
+    latest_versions = latest_registered_versions(registry, CORE_PACKAGE_NAMES)
+    manifest_versions = resolved_versions(CORE_PACKAGE_NAMES)
+    results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, manifest_versions)
+
+    println()
+    println("Core package freshness check:")
+    for result in results
+        status = result.ok ? "ok" : "stale"
+        println(
+            "  $(result.package): resolved $(version_label(result.resolved)); ",
+            "latest registered $(version_label(result.latest)) [$status]",
+        )
+    end
+
+    all(result -> result.ok, results) && return
+
+    println()
+    println("Ecosystem canary resolved an older core package version for $tier.")
+    println("This usually means a downstream compat bound still excludes the latest registered release.")
+    println("Compatibility matrix for this tier:")
+    print_compat_matrix(unique(vcat(CORE_PACKAGE_NAMES, packages)))
+    exit(1)
+end
+
 function resolve_packages(tier, packages)
     println("Ecosystem canary tier: $tier")
     println("Packages: $(join(packages, ", "))")
     Pkg.activate(; temp = true)
-    ensure_general_registry()
+    registry = ensure_general_registry()
     try
         Pkg.add(packages)
         Pkg.resolve()
@@ -66,6 +132,7 @@ function resolve_packages(tier, packages)
         println()
         exit(1)
     end
+    check_latest_core_packages(registry, tier, packages)
 end
 
 function import_package(name)

--- a/scripts/ecosystem_canary.jl
+++ b/scripts/ecosystem_canary.jl
@@ -53,6 +53,25 @@ function print_compat_matrix(packages)
     end
 end
 
+function is_julia_compatible(compatibility)
+    julia_versions = get(compatibility, Pkg.Registry.JULIA_UUID, Pkg.Types.VersionSpec())
+    return VERSION in julia_versions
+end
+
+function latest_installable_registered_version(package, version_info, compatibility_info)
+    candidates = VersionNumber[]
+    for (version, info) in version_info
+        info.yanked && continue
+        isempty(version.prerelease) || continue
+        is_julia_compatible(get(compatibility_info, version, Dict())) || continue
+        push!(candidates, version)
+    end
+    if isempty(candidates)
+        error("no unyanked stable release of $package is compatible with Julia $VERSION")
+    end
+    return maximum(candidates)
+end
+
 function latest_registered_versions(registry, package_names)
     uuid_by_name = Dict(entry.name => uuid for (uuid, entry) in registry.pkgs)
     versions = Dict{String,VersionNumber}()
@@ -60,7 +79,8 @@ function latest_registered_versions(registry, package_names)
         uuid = get(uuid_by_name, package, nothing)
         uuid === nothing && error("$package is not available in the General registry")
         info = Pkg.Registry.registry_info(registry.pkgs[uuid])
-        versions[package] = maximum(keys(info.version_info))
+        compatibility_info = Pkg.Registry.compat_info(info)
+        versions[package] = latest_installable_registered_version(package, info.version_info, compatibility_info)
     end
     return versions
 end
@@ -99,7 +119,7 @@ function check_latest_core_packages(registry, tier, packages)
         status = result.ok ? "ok" : "stale"
         println(
             "  $(result.package): resolved $(version_label(result.resolved)); ",
-            "latest registered $(version_label(result.latest)) [$status]",
+            "latest installable registered $(version_label(result.latest)) [$status]",
         )
     end
 

--- a/scripts/ecosystem_canary.jl
+++ b/scripts/ecosystem_canary.jl
@@ -2,7 +2,7 @@
 
 using Pkg
 
-const CORE_PACKAGE_NAMES = ["QUBOTools", "ToQUBO", "QUBODrivers"]
+const CORE_PACKAGE_NAMES = ["PseudoBooleanOptimization", "QUBOTools", "ToQUBO", "QUBODrivers"]
 
 function parse_args(args)
     tier = "custom"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/ecosystem_canary.jl
+++ b/test/ecosystem_canary.jl
@@ -1,0 +1,49 @@
+using Test
+
+include(joinpath(@__DIR__, "..", "scripts", "ecosystem_canary.jl"))
+
+function test_ecosystem_canary()
+    @testset "Ecosystem Canary" begin
+        tier, allow_import_failure, packages = parse_args([
+            "--tier",
+            "tier-2",
+            "--allow-import-failure",
+            "DWave",
+            "QUBOTools",
+            "QUBO",
+        ])
+
+        @test tier == "tier-2"
+        @test allow_import_failure == Set(["DWave"])
+        @test packages == ["QUBOTools", "QUBO"]
+        @test CORE_PACKAGE_NAMES == ["QUBOTools", "ToQUBO", "QUBODrivers"]
+
+        latest_versions = Dict(
+            "QUBOTools" => v"0.14.4",
+            "ToQUBO" => v"0.5.0",
+            "QUBODrivers" => v"0.6.3",
+        )
+        fresh_manifest = copy(latest_versions)
+        stale_manifest = merge(fresh_manifest, Dict("QUBOTools" => v"0.13.3"))
+
+        fresh_results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, fresh_manifest)
+        @test all(result -> result.ok, fresh_results)
+
+        stale_results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, stale_manifest)
+        @test !all(result -> result.ok, stale_results)
+        @test only(result for result in stale_results if result.package == "QUBOTools").resolved == v"0.13.3"
+        @test version_label(nothing) == "missing"
+
+        root = joinpath(@__DIR__, "..")
+        workflow = read(joinpath(root, ".github", "workflows", "ecosystem-canary.yml"), String)
+        script = read(joinpath(root, "scripts", "ecosystem_canary.jl"), String)
+
+        for package in CORE_PACKAGE_NAMES
+            @test occursin(package, workflow)
+        end
+        @test occursin("Pkg.add(packages)", script)
+        @test !occursin("Pkg.develop", script)
+    end
+
+    return nothing
+end

--- a/test/ecosystem_canary.jl
+++ b/test/ecosystem_canary.jl
@@ -45,13 +45,38 @@ function test_ecosystem_canary()
             v"0.2.5"
         @test version_label(nothing) == "missing"
 
+        stable_version_info = Dict(
+            v"1.0.0" => (; yanked = false),
+            v"1.1.0" => (; yanked = true),
+            v"1.2.0-beta" => (; yanked = false),
+            v"1.3.0" => (; yanked = false),
+        )
+        stable_compatibility_info = Dict(
+            v"1.0.0" => Dict(Pkg.Registry.JULIA_UUID => Pkg.Types.VersionSpec()),
+            v"1.1.0" => Dict(Pkg.Registry.JULIA_UUID => Pkg.Types.VersionSpec()),
+            v"1.2.0-beta" => Dict(Pkg.Registry.JULIA_UUID => Pkg.Types.VersionSpec()),
+            v"1.3.0" => Dict(Pkg.Registry.JULIA_UUID => Pkg.Types.semver_spec("99")),
+        )
+        @test latest_installable_registered_version(
+            "Example",
+            stable_version_info,
+            stable_compatibility_info,
+        ) == v"1.0.0"
+        @test_throws ErrorException latest_installable_registered_version(
+            "Example",
+            Dict(v"1.0.0" => (; yanked = true)),
+            Dict(v"1.0.0" => Dict(Pkg.Registry.JULIA_UUID => Pkg.Types.VersionSpec())),
+        )
+
         root = joinpath(@__DIR__, "..")
         workflow = read(joinpath(root, ".github", "workflows", "ecosystem-canary.yml"), String)
+        maintenance = read(joinpath(root, "docs", "src", "maintenance.md"), String)
         script = read(joinpath(root, "scripts", "ecosystem_canary.jl"), String)
 
         for package in CORE_PACKAGE_NAMES
             @test occursin(package, workflow)
         end
+        @test occursin("intentionally global", maintenance)
         @test occursin("Pkg.add(packages)", script)
         @test !occursin("Pkg.develop", script)
     end

--- a/test/ecosystem_canary.jl
+++ b/test/ecosystem_canary.jl
@@ -16,22 +16,33 @@ function test_ecosystem_canary()
         @test tier == "tier-2"
         @test allow_import_failure == Set(["DWave"])
         @test packages == ["QUBOTools", "QUBO"]
-        @test CORE_PACKAGE_NAMES == ["QUBOTools", "ToQUBO", "QUBODrivers"]
+        @test CORE_PACKAGE_NAMES == [
+            "PseudoBooleanOptimization",
+            "QUBOTools",
+            "ToQUBO",
+            "QUBODrivers",
+        ]
 
         latest_versions = Dict(
-            "QUBOTools" => v"0.14.4",
+            "PseudoBooleanOptimization" => v"0.2.6",
+            "QUBOTools" => v"0.15.0",
             "ToQUBO" => v"0.5.0",
             "QUBODrivers" => v"0.6.3",
         )
         fresh_manifest = copy(latest_versions)
-        stale_manifest = merge(fresh_manifest, Dict("QUBOTools" => v"0.13.3"))
+        stale_manifest = merge(fresh_manifest, Dict("QUBOTools" => v"0.14.4"))
+        stale_pbo_manifest = merge(fresh_manifest, Dict("PseudoBooleanOptimization" => v"0.2.5"))
 
         fresh_results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, fresh_manifest)
         @test all(result -> result.ok, fresh_results)
 
         stale_results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, stale_manifest)
         @test !all(result -> result.ok, stale_results)
-        @test only(result for result in stale_results if result.package == "QUBOTools").resolved == v"0.13.3"
+        @test only(result for result in stale_results if result.package == "QUBOTools").resolved == v"0.14.4"
+        stale_pbo_results = core_version_results(CORE_PACKAGE_NAMES, latest_versions, stale_pbo_manifest)
+        @test !all(result -> result.ok, stale_pbo_results)
+        @test only(result for result in stale_pbo_results if result.package == "PseudoBooleanOptimization").resolved ==
+            v"0.2.5"
         @test version_label(nothing) == "missing"
 
         root = joinpath(@__DIR__, "..")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,13 @@ include("multimake_utils.jl")
 include("docs_assets.jl")
 include("package_metadata.jl")
 include("qubotools_plots.jl")
+include("ecosystem_canary.jl")
 
 function main()
     test_docs_assets()
     test_package_metadata()
     test_qubotools_plots()
+    test_ecosystem_canary()
     test_spin_model()
     test_multimake_utils()
 


### PR DESCRIPTION
## Summary

Adds a freshness check to the ecosystem canary so it fails when the registry-resolved stack does not use the latest registered core packages:

- `PseudoBooleanOptimization`
- `QUBOTools`
- `ToQUBO`
- `QUBODrivers`

The canary still resolves packages from the General registry in a temporary Julia environment. It now compares the resolved manifest against the latest registered versions and prints the compatibility matrix when a stale core package is selected.

## Why

The existing canary caught resolver/import failures, but it could stay green when a downstream package still capped a shared lower-layer dependency and the resolver fell back to an older compatible version. That is exactly the failure mode tracked in #46.

Including `PseudoBooleanOptimization` keeps the same release-wave check attached to the PBO layer while the stack is being updated.

## Canary Status

This PR is expected to make the ecosystem canary red until downstream registered releases are updated.

Current local evidence after `QUBOTools v0.15.0` reached General:

- The canary dynamically detects `PseudoBooleanOptimization v0.2.6`, `QUBOTools v0.15.0`, `ToQUBO v0.5.0`, and `QUBODrivers v0.6.3` as the latest registered core packages.
- The core stack currently resolves `PseudoBooleanOptimization v0.2.6`, `QUBOTools v0.14.4`, `ToQUBO v0.5.0`, and `QUBODrivers v0.6.3`.
- The new freshness check fails as intended: `QUBOTools` resolves below latest.
- The compatibility matrix points at `ToQUBO v0.5.0` and `QUBODrivers v0.6.3` still allowing `QUBOTools 0.11 - 0.14` / `0.10 - 0.14`, so the latest core stack cannot yet compose with `QUBOTools 0.15.0`.

This should turn green without changing the canary once the affected downstream/core packages widen compat and publish registered patch/minor releases.

## Validation

- `julia +release --project=test -e 'include("test/ecosystem_canary.jl"); test_ecosystem_canary()'` passed.
- `env JULIA_DEPOT_PATH=/tmp/qubo-pr48-pbo-core JULIA_PKG_PRECOMPILE_AUTO=0 julia +release --startup-file=no scripts/ecosystem_canary.jl --tier core PseudoBooleanOptimization QUBOTools ToQUBO QUBODrivers` produced the expected freshness failure after `QUBOTools v0.15.0`.
- `git diff --check` passed.
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` is currently blocked by the registered compat conflict: `QUBODrivers v0.6.3` caps `QUBOTools` to `0.10 - 0.14` while the resolver sees `QUBOTools v0.15.0`.

## Branch Hygiene

- Base branch: `main`
- Source branch: `codex/core-stack-canary-freshness`
- Branch created from current local `main`
- Not stacked
