### PR TITLE
ci: deduplicate coverage and documentation setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,15 @@ jobs:
           - version: '1.10'
             os: ubuntu-latest
             arch: x64
+            coverage: false
           - version: '1'
             os: ubuntu-latest
             arch: x64
+            coverage: true
           - version: '1'
             os: windows-latest
             arch: x64
+            coverage: false
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -31,8 +34,12 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.coverage }}
       - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.coverage
       - uses: codecov/codecov-action@v7
+        if: matrix.coverage
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,16 +24,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs/ docs/make.jl
-  build-multidocs:
-    runs-on: ubuntu-latest
-    needs: build-docs
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1.10'
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(path=@__DIR__); Pkg.instantiate()'
       - name: Aggregate and deploy
         run: |
           git config user.name github-actions


### PR DESCRIPTION
## Summary

- make Julia current/Ubuntu the only coverage producer while retaining the full three-job compatibility matrix
- run package docs and multidocs sequentially after one Julia setup and one `docs/` environment installation
- preserve existing PR, Dependabot, push, and tag deployment behavior

## Validation

- `actionlint`
- `git diff --check`
- CI and documentation workflows (post-push; timings to be recorded from Actions)

## Measurement

Audit baselines from #60:

- CI: 12.9 aggregate runner-minutes; 73 seconds in three coverage-processing steps before uploads
- Documentation: 5m13s critical path, including two serial 1m57s dependency installations

Measured on this PR:

- CI attempt 1: 12.3 aggregate runner-minutes; longest job 5m09s
- CI warm rerun: 5.2 aggregate runner-minutes; longest job 2m29s
- only Julia current/Ubuntu processed and uploaded coverage; both noncanonical jobs logged `coverage=false` and skipped upload
- consolidated documentation job: 2m40s on attempt 1 and 3m05s warm, versus the 5m13s audited baseline

The docs consolidation roughly halved the observed critical path without changing the sequential deployment order or outputs. Warm CI is 7.1 runner-minutes below the first run; runner/cache variance means these figures are evidence, not a benchmark guarantee.

## Branch Hygiene

- Base: `main` at `05c6a6fa6c51a8256acb67db558ccac625097e3b`
- Not stacked; open PR #59 changes `test/package_metadata.jl`, not either workflow changed here.
- The `build-docs` check name is preserved; the redundant `build-multidocs` job is folded into it.

Closes #60
