### PR TITLE
Cite the published QUBO.jl journal article

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,10 +1,10 @@
 % If you use this software, please cite it as below.
-@misc{qubojl:2023,
-  title         = {QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}, 
-  author        = {Pedro {Maciel Xavier} and Pedro Ripper and Tiago Andrade and Joaquim {Dias Garcia} and Nelson Maculan and David E. {Bernal Neira}},
-  year          = {2023},
-  doi           = {10.48550/arXiv.2307.02577},
-  eprint        = {2307.02577},
-  archivePrefix = {arXiv},
-  primaryClass  = {math.OC},
+@article{qubojl:2026,
+  title   = {QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization},
+  author  = {Pedro {Maciel Xavier} and Pedro Ripper and Tiago Andrade and Joaquim {Dias Garcia} and Nelson Maculan and David E. {Bernal Neira}},
+  journal = {Optimization Methods and Software},
+  year    = {2026},
+  pages   = {1--24},
+  doi     = {10.1080/10556788.2026.2702926},
+  url     = {https://doi.org/10.1080/10556788.2026.2702926},
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,31 @@ authors:
   orcid: "https://orcid.org/0000-0002-8308-5016"
 title: "QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization"
 version: "0.6.0"
-doi: 10.48550/arXiv.2307.02577
 date-released: 2026-06-08
 url: "https://github.com/JuliaQUBO/QUBO.jl"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Maciel Xavier"
+    given-names: "Pedro"
+    orcid: "https://orcid.org/0000-0002-4678-4942"
+  - family-names: "Ripper"
+    given-names: "Pedro"
+    orcid: "https://orcid.org/0000-0002-2227-3689"
+  - family-names: "Andrade"
+    given-names: "Tiago"
+  - family-names: "Dias Garcia"
+    given-names: "Joaquim"
+    orcid: "https://orcid.org/0000-0002-7721-8564"
+  - family-names: "Maculan"
+    given-names: "Nelson"
+    orcid: "https://orcid.org/0000-0002-3897-3356"
+  - family-names: "Bernal Neira"
+    given-names: "David E."
+    orcid: "https://orcid.org/0000-0002-8308-5016"
+  title: "QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization"
+  journal: "Optimization Methods and Software"
+  year: 2026
+  start: 1
+  end: 24
+  doi: 10.1080/10556788.2026.2702926

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaqubo.github.io/QUBO.jl/dev/)
 [![Zenodo/DOI](https://zenodo.org/badge/614041491.svg)](https://zenodo.org/badge/latestdoi/614041491)
 [![JuliaCon 2022](https://img.shields.io/badge/JuliaCon-2022-9558b2)](https://www.youtube.com/watch?v=OTmzlTbqdNo)
+[![Journal article](https://img.shields.io/badge/DOI-10.1080%2F10556788.2026.2702926-blue.svg)](https://www.tandfonline.com/doi/full/10.1080/10556788.2026.2702926)
 [![arXiv](https://img.shields.io/badge/arXiv-2307.02577-b31b1b.svg)](https://arxiv.org/abs/2307.02577)
 
 *A Julia ecosystem for Quadratic Unconstrained Binary Optimization*
@@ -213,17 +214,17 @@ With [QUBOTools.jl](https://github.com/JuliaQUBO/QUBOTools.jl) it is possible to
 
 ## Citing [QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl) 📑
 
-If you find [QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl) and its packages useful in your work, we kindly request that you cite the following paper (preprint):
+If you find [QUBO.jl](https://github.com/JuliaQUBO/QUBO.jl) and its packages useful in your work, we kindly request that you cite the following [journal article](https://www.tandfonline.com/doi/full/10.1080/10556788.2026.2702926). The [arXiv preprint](https://arxiv.org/abs/2307.02577) remains available.
 
 ```tex
-@misc{qubojl:2023,
-  title         = {QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization}, 
-  author        = {Pedro {Maciel Xavier} and Pedro Ripper and Tiago Andrade and Joaquim {Dias Garcia} and Nelson Maculan and David E. {Bernal Neira}},
-  year          = {2023},
-  doi           = {10.48550/arXiv.2307.02577},
-  eprint        = {2307.02577},
-  archivePrefix = {arXiv},
-  primaryClass  = {math.OC},
+@article{qubojl:2026,
+  title   = {QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization},
+  author  = {Pedro {Maciel Xavier} and Pedro Ripper and Tiago Andrade and Joaquim {Dias Garcia} and Nelson Maculan and David E. {Bernal Neira}},
+  journal = {Optimization Methods and Software},
+  year    = {2026},
+  pages   = {1--24},
+  doi     = {10.1080/10556788.2026.2702926},
+  url     = {https://doi.org/10.1080/10556788.2026.2702926},
 }
 ```
 


### PR DESCRIPTION
## Summary

- link the published *Optimization Methods and Software* article from the README
- update the README and `CITATION.bib` BibTeX entries to the journal publication
- record the journal article as the preferred citation in `CITATION.cff`
- retain the existing arXiv badge and preprint link

## Verification

- `git diff --check`
- parsed `CITATION.cff` as YAML and verified the journal, DOI, year, and article type
