### PR TITLE
Sync citation metadata with QUBO.jl v0.6.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -20,8 +20,8 @@ authors:
   given-names: "David E."
   orcid: "https://orcid.org/0000-0002-8308-5016"
 title: "QUBO.jl: A Julia Ecosystem for Quadratic Unconstrained Binary Optimization"
-version: "0.6.0"
-date-released: 2026-06-08
+version: "0.6.2"
+date-released: "2026-06-26"
 url: "https://github.com/JuliaQUBO/QUBO.jl"
 preferred-citation:
   type: article


### PR DESCRIPTION
## Summary

- synchronize `CITATION.cff` with the current QUBO.jl v0.6.2 release
- record the verified 2026-06-26 release date
- quote the date so YAML parsers preserve the CFF schema's string type

## Verification

- confirmed `CITATION.cff` version matches `Project.toml`
- confirmed the release date against the published GitHub v0.6.2 release
- validated `CITATION.cff` against the official CFF 1.2.0 schema
- `git diff --check`
