### PR TITLE
Clarify package-local release preflight examples

### DIFF
--- a/docs/src/maintenance.md
+++ b/docs/src/maintenance.md
@@ -175,8 +175,12 @@ branches that trigger CI.
 ## Release Guardrails
 
 Use package-local release checks before tagging or registering an individual
-package release. The release preflight belongs in the package repository, for
-example `scripts/release_check.jl`, and should catch release-sensitive metadata
+package release. The release preflight belongs in that package's repository;
+see the
+[`ToQUBO.jl` preflight](https://github.com/JuliaQUBO/ToQUBO.jl/blob/main/scripts/release_check.jl)
+and
+[`QUBOTools.jl` preflight](https://github.com/JuliaQUBO/QUBOTools.jl/blob/main/scripts/release_check.jl)
+for concrete examples. These checks should catch release-sensitive metadata
 that normal unit tests can miss:
 
 - root, docs, and test `Project.toml` version and compatibility drift;
@@ -184,6 +188,11 @@ that normal unit tests can miss:
   `Breaking changes` and `Changelog` wording for pre-1.0 minor releases;
 - TagBot, Registrator, General pull request, and fresh `Pkg.add` verification
   checklist items.
+
+QUBO.jl does not keep a separate `scripts/release_check.jl`. Its
+package-specific version and compatibility invariants run with the normal test
+suite in `test/package_metadata.jl`; the compatibility matrix and ecosystem
+canary below provide the post-release coordination layer.
 
 Use the QUBO.jl ecosystem canary after release work reaches the registry, or
 whenever a coordinated release wave changes cross-package compatibility. The

--- a/test/docs_assets.jl
+++ b/test/docs_assets.jl
@@ -44,7 +44,19 @@ function test_docs_assets()
         @test occursin("package-ecosystem: \"julia\"", maintenance)
         @test occursin("omits `test/` because `test/Project.toml` has no `[compat]`", maintenance)
         @test occursin("COMPATHELPER_PRIV", maintenance)
-        @test occursin("scripts/release_check.jl", maintenance)
+        @test occursin(
+            "JuliaQUBO/ToQUBO.jl/blob/main/scripts/release_check.jl",
+            maintenance,
+        )
+        @test occursin(
+            "JuliaQUBO/QUBOTools.jl/blob/main/scripts/release_check.jl",
+            maintenance,
+        )
+        @test occursin(
+            "QUBO.jl does not keep a separate `scripts/release_check.jl`",
+            maintenance,
+        )
+        @test occursin("test/package_metadata.jl", maintenance)
         @test occursin("Breaking changes", maintenance)
         @test occursin("post-release coordination check", maintenance)
         @test occursin("compatibility matrix on every run", maintenance)


### PR DESCRIPTION
## Summary

- clarify that release preflights live in the package repository being released
- link directly to the maintained ToQUBO.jl and QUBOTools.jl preflight scripts
- document QUBO.jl's own package-metadata tests and ecosystem coordination role
- strengthen the documentation assertions around that distinction

## Acceptance criteria

- [x] The guide does not imply that QUBO.jl contains a package-local release
      script.
- [x] Live package-local preflight examples are linked.
- [x] QUBO.jl's metadata tests, compatibility matrix, and canary are identified.
- [x] Relevant documentation tests pass.

## Tests

- `julia +release --project=. -e 'using Test; include("test/docs_assets.jl"); test_docs_assets()'` — 40/40 passed
- `julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed
- `julia +release --project=docs docs/make.jl --skip-deploy` — passed
- `git diff --cached --check` — passed before commit

## Branch Hygiene

- Base branch: `main`
- Source branch point: `7b37b6759faf34a142edef298d175ca512a5524f`
- Stacked: no
- Prerequisite PRs: none

Closes #64.
